### PR TITLE
Make Box ID optional for MSP connection

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -10,10 +10,16 @@ FIREWALLA_MSP_TOKEN=your_msp_access_token_here
 # Format: yourdomain.firewalla.net (without https://)
 FIREWALLA_MSP_ID=yourdomain.firewalla.net
 
-# Your Firewalla Box Global ID (GID)
+# Optional: Your Firewalla Box Global ID (GID)
+# This is optional - you can retrieve box IDs via the get_boxes tool
+# If not provided, API calls will return data for all boxes you have access to
 # Find this in the box details in your MSP portal
 # Format: UUID like 1eb71e38-3a95-4371-8903-ace24c83ab49
-FIREWALLA_BOX_ID=your_box_gid_here
+# FIREWALLA_BOX_ID=your_box_gid_here
+
+# Optional: Default Box ID for convenience tools
+# Used as a default when box_id is not explicitly provided to tools
+# FIREWALLA_DEFAULT_BOX_ID=your_default_box_gid_here
 
 # Optional: API timeout in milliseconds (default: 30000)
 FIREWALLA_API_TIMEOUT=30000

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -87,9 +87,15 @@ npm run setup:hooks      # Install git hooks
 1. Create `.env` file in project root
 2. Add the following environment variables:
 ```env
+# Required
 FIREWALLA_MSP_TOKEN=your_msp_access_token_here
 FIREWALLA_MSP_ID=yourdomain.firewalla.net
-FIREWALLA_BOX_ID=your_box_gid_here
+
+# Optional - can be retrieved via get_boxes tool
+# FIREWALLA_BOX_ID=your_box_gid_here
+
+# Optional - default box ID for convenience
+# FIREWALLA_DEFAULT_BOX_ID=your_default_box_gid_here
 ```
 
 ### Getting MSP Credentials
@@ -97,7 +103,13 @@ FIREWALLA_BOX_ID=your_box_gid_here
 2. Navigate to Account Settings > API Settings
 3. Generate a personal access token
 4. Note your MSP domain (e.g., `yourdomain.firewalla.net`)
-5. Find your Box GID (Global ID) in the box details - this is the long identifier that looks like `1eb71e38-3a95-4371-8903-ace24c83ab49`
+
+### About Box IDs
+- **Box ID is now optional** - you can retrieve available boxes using the `get_boxes` tool
+- If no box ID is configured, API calls return data for all boxes you have access to
+- You can optionally set `FIREWALLA_BOX_ID` to filter all queries to a specific box by default
+- Use `FIREWALLA_DEFAULT_BOX_ID` for convenience tools that need a default box
+- Box GID format: UUID like `1eb71e38-3a95-4371-8903-ace24c83ab49`
 
 ## Feature Flag System
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -109,7 +109,7 @@ FIREWALLA_MSP_ID=yourdomain.firewalla.net
 - If no box ID is configured, API calls return data for all boxes you have access to
 - You can optionally set `FIREWALLA_BOX_ID` to filter all queries to a specific box by default
 - Use `FIREWALLA_DEFAULT_BOX_ID` for convenience tools that need a default box
-- Box GID format: UUID like `1eb71e38-3a95-4371-8903-ace24c83ab49`
+- Box GID format: UUID-like `1eb71e38-3a95-4371-8903-ace24c83ab49`
 
 ## Feature Flag System
 

--- a/README.md
+++ b/README.md
@@ -105,16 +105,19 @@ npm run build
 Create a `.env` file with your Firewalla credentials:
 
 ```env
+# Required
 FIREWALLA_MSP_TOKEN=your_msp_access_token_here
 FIREWALLA_MSP_ID=yourdomain.firewalla.net
-FIREWALLA_BOX_ID=your_box_gid_here
+
+# Optional - filters all queries to a specific box
+# FIREWALLA_BOX_ID=your_box_gid_here
 ```
 
 **Getting Your Credentials:**
 1. Log into your Firewalla MSP portal at `https://yourdomain.firewalla.net`
 2. Your MSP ID is the full domain (e.g., `company123.firewalla.net`)
 3. Generate an access token in API settings
-4. Find your Box GID (Group ID) in device settings - this is your unique device identifier
+4. (Optional) Find your Box GID in device settings to filter queries to a specific box, or retrieve available boxes using the `get_boxes` tool
 
 ### 3. Build and Start
 

--- a/TROUBLESHOOTING.md
+++ b/TROUBLESHOOTING.md
@@ -38,7 +38,7 @@ export PATH=~/.npm-global/bin:$PATH
 
 **Check your credentials:**
 1. Verify MSP token is valid (log into MSP portal)
-2. Check Box ID format (should be long UUID like `1eb71e38-3a95-4371-8903-ace24c83ab49`)
+2. Check Box ID format (should be UUID-like `1eb71e38-3a95-4371-8903-ace24c83ab49`)
 3. Confirm MSP domain is correct (`yourdomain.firewalla.net`)
 
 **Test credentials manually:**

--- a/docs/error-handling-guide.md
+++ b/docs/error-handling-guide.md
@@ -724,7 +724,7 @@ const errorResponseTimes = {
   "tool": "firewalla_client",
   "errorType": "authentication_error",
   "details": {
-    "requiredVars": ["FIREWALLA_MSP_TOKEN", "FIREWALLA_MSP_ID", "FIREWALLA_BOX_ID"]
+    "requiredVars": ["FIREWALLA_MSP_TOKEN", "FIREWALLA_MSP_ID"]
   }
 }
 ```

--- a/docs/geographic-data-handling-guide.md
+++ b/docs/geographic-data-handling-guide.md
@@ -1753,5 +1753,3 @@ npm run geo:analyze:unknowns
 # Performance benchmark
 npm run geo:benchmark
 ```
-
-This comprehensive guide provides the foundation for understanding and implementing robust geographic data handling in the Firewalla MCP Server, ensuring consistent, high-quality location intelligence while maintaining optimal performance.

--- a/docs/security-policy-guide.md
+++ b/docs/security-policy-guide.md
@@ -433,5 +433,3 @@ Test security implementation:
 2. **Input Validation Tests**: Test malicious input handling
 3. **Audit Log Tests**: Verify audit log generation
 4. **Risk Assessment Tests**: Test risk score calculations
-
-This comprehensive security framework ensures enterprise-grade protection while maintaining usability for convenience tools.

--- a/docs/tool-descriptions-enhancement-guide.md
+++ b/docs/tool-descriptions-enhancement-guide.md
@@ -674,5 +674,3 @@ The tool description enhancement initiative resolved critical discrepancies betw
 - **Better User Experience**: Clear guidance prevents common errors and timeouts
 - **Consistent Standards**: All tools follow the same description and limit patterns
 - **Maintainable Documentation**: Centralized patterns make updates easier
-
-These enhancements ensure that users can effectively utilize the Firewalla MCP Server while maintaining optimal performance and reliability.

--- a/src/config/config.ts
+++ b/src/config/config.ts
@@ -27,7 +27,6 @@ import type { FirewallaConfig } from '../types';
 import {
   getRequiredEnvVar,
   getOptionalEnvInt,
-  getOptionalEnvVar,
 } from '../utils/env.js';
 import { getTestConfig } from './test-mode-config.js';
 
@@ -54,7 +53,7 @@ dotenv.config();
 export function getConfig(): FirewallaConfig {
   // Check if running in test mode (for Docker health checks)
   const testMode =
-    getOptionalEnvVar('MCP_TEST_MODE', 'false').toLowerCase() === 'true';
+    (process.env.MCP_TEST_MODE || 'false').toLowerCase() === 'true';
 
   if (testMode) {
     console.log('Running in test mode - using dummy credentials');

--- a/src/config/config.ts
+++ b/src/config/config.ts
@@ -8,9 +8,9 @@
  * Required environment variables:
  * - FIREWALLA_MSP_TOKEN: MSP API access token
  * - FIREWALLA_MSP_ID: MSP domain (e.g., 'yourdomain.firewalla.net')
- * - FIREWALLA_BOX_ID: Firewalla box Global ID (GID)
  *
  * Optional environment variables:
+ * - FIREWALLA_BOX_ID: Firewalla box Global ID (GID) - can be provided as default or per-call
  * - API_TIMEOUT: Request timeout in milliseconds (default: 30000)
  * - API_RATE_LIMIT: Requests per minute limit (default: 100)
  * - CACHE_TTL: Cache time-to-live in seconds (default: 300)
@@ -67,7 +67,7 @@ export function getConfig(): FirewallaConfig {
     mspToken: getRequiredEnvVar('FIREWALLA_MSP_TOKEN'),
     mspId,
     mspBaseUrl: `https://${mspId}`,
-    boxId: getRequiredEnvVar('FIREWALLA_BOX_ID'),
+    boxId: process.env.FIREWALLA_BOX_ID || undefined,
     apiTimeout: getOptionalEnvInt('API_TIMEOUT', 30000, 1000, 300000), // 1s to 5min
     rateLimit: getOptionalEnvInt('API_RATE_LIMIT', 100, 1, 1000), // 1 to 1000 requests per minute
     cacheTtl: getOptionalEnvInt('CACHE_TTL', 300, 0, 3600), // 0s to 1 hour

--- a/src/config/security.ts
+++ b/src/config/security.ts
@@ -278,6 +278,14 @@ export class SecurityManager {
     if (boxId) {
       if (boxId.length < 10) {
         errors.push('FIREWALLA_BOX_ID appears to be too short');
+      } else if (
+        !/^[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}$/i.test(
+          boxId
+        )
+      ) {
+        warnings.push(
+          'FIREWALLA_BOX_ID does not appear to be a valid UUID format'
+        );
       }
     } else {
       warnings.push(

--- a/src/config/security.ts
+++ b/src/config/security.ts
@@ -257,7 +257,7 @@ export class SecurityManager {
   } {
     const errors: string[] = [];
     const warnings: string[] = [];
-    const required = ['FIREWALLA_MSP_TOKEN', 'FIREWALLA_BOX_ID'];
+    const required = ['FIREWALLA_MSP_TOKEN'];
 
     for (const envVar of required) {
       if (!process.env[envVar]) {
@@ -273,12 +273,24 @@ export class SecurityManager {
       errors.push('FIREWALLA_MSP_TOKEN contains invalid characters');
     }
 
-    // Check for FIREWALLA_DEFAULT_BOX_ID if convenience tools are used
-    if (!process.env.FIREWALLA_DEFAULT_BOX_ID) {
-      warnings.push(
-        'FIREWALLA_DEFAULT_BOX_ID not set - convenience tools will require explicit box_id parameters'
-      );
+    // Validate FIREWALLA_BOX_ID if provided
+    const boxId = process.env.FIREWALLA_BOX_ID;
+    if (boxId) {
+      if (boxId.length < 10) {
+        errors.push('FIREWALLA_BOX_ID appears to be too short');
+      }
     } else {
+      warnings.push(
+        'FIREWALLA_BOX_ID not set - box ID must be provided per-call or via FIREWALLA_DEFAULT_BOX_ID'
+      );
+    }
+
+    // Check for FIREWALLA_DEFAULT_BOX_ID if convenience tools are used
+    if (!process.env.FIREWALLA_DEFAULT_BOX_ID && !boxId) {
+      warnings.push(
+        'Neither FIREWALLA_BOX_ID nor FIREWALLA_DEFAULT_BOX_ID set - box ID will be required for all operations'
+      );
+    } else if (process.env.FIREWALLA_DEFAULT_BOX_ID) {
       // Validate default box ID format
       const defaultBoxId = process.env.FIREWALLA_DEFAULT_BOX_ID;
       if (

--- a/src/debug/tools.ts
+++ b/src/debug/tools.ts
@@ -216,7 +216,7 @@ export class DebugTools {
     const issues: Array<{ level: 'error' | 'warning'; message: string }> = [];
 
     // Check environment variables
-    const requiredVars = ['FIREWALLA_MSP_TOKEN', 'FIREWALLA_BOX_ID'];
+    const requiredVars = ['FIREWALLA_MSP_TOKEN'];
     for (const varName of requiredVars) {
       if (
         process.env[varName] === undefined ||
@@ -228,6 +228,17 @@ export class DebugTools {
           message: `Missing required environment variable: ${varName}`,
         });
       }
+    }
+
+    // Check optional box ID - warn if not set
+    if (
+      !process.env.FIREWALLA_BOX_ID &&
+      !process.env.FIREWALLA_DEFAULT_BOX_ID
+    ) {
+      issues.push({
+        level: 'warning',
+        message: 'Neither FIREWALLA_BOX_ID nor FIREWALLA_DEFAULT_BOX_ID set - box ID will be required for specific operations',
+      });
     }
 
     // Check API connectivity
@@ -293,7 +304,8 @@ Cache Information:
 
 Configuration:
 - MSP Token: ${process.env.FIREWALLA_MSP_TOKEN !== undefined && process.env.FIREWALLA_MSP_TOKEN !== null && process.env.FIREWALLA_MSP_TOKEN !== '' ? 'Set' : 'Missing'}
-- Box ID: ${process.env.FIREWALLA_BOX_ID !== undefined && process.env.FIREWALLA_BOX_ID !== null && process.env.FIREWALLA_BOX_ID !== '' ? 'Set' : 'Missing'}
+- Box ID: ${process.env.FIREWALLA_BOX_ID !== undefined && process.env.FIREWALLA_BOX_ID !== null && process.env.FIREWALLA_BOX_ID !== '' ? 'Set' : 'Not Set (Optional)'}
+- Default Box ID: ${process.env.FIREWALLA_DEFAULT_BOX_ID !== undefined && process.env.FIREWALLA_DEFAULT_BOX_ID !== null && process.env.FIREWALLA_DEFAULT_BOX_ID !== '' ? 'Set' : 'Not Set'}
 - Base URL: ${process.env.FIREWALLA_MSP_BASE_URL ?? 'Default'}
 - Log Level: ${process.env.LOG_LEVEL ?? 'Default'}
 

--- a/src/debug/tools.ts
+++ b/src/debug/tools.ts
@@ -218,11 +218,7 @@ export class DebugTools {
     // Check environment variables
     const requiredVars = ['FIREWALLA_MSP_TOKEN'];
     for (const varName of requiredVars) {
-      if (
-        process.env[varName] === undefined ||
-        process.env[varName] === null ||
-        process.env[varName] === ''
-      ) {
+      if (!process.env[varName]) {
         issues.push({
           level: 'error',
           message: `Missing required environment variable: ${varName}`,
@@ -303,9 +299,9 @@ Cache Information:
 - Sample Keys: ${cacheStats.keys.slice(0, 5).join(', ')}
 
 Configuration:
-- MSP Token: ${process.env.FIREWALLA_MSP_TOKEN !== undefined && process.env.FIREWALLA_MSP_TOKEN !== null && process.env.FIREWALLA_MSP_TOKEN !== '' ? 'Set' : 'Missing'}
-- Box ID: ${process.env.FIREWALLA_BOX_ID !== undefined && process.env.FIREWALLA_BOX_ID !== null && process.env.FIREWALLA_BOX_ID !== '' ? 'Set' : 'Not Set (Optional)'}
-- Default Box ID: ${process.env.FIREWALLA_DEFAULT_BOX_ID !== undefined && process.env.FIREWALLA_DEFAULT_BOX_ID !== null && process.env.FIREWALLA_DEFAULT_BOX_ID !== '' ? 'Set' : 'Not Set'}
+- MSP Token: ${process.env.FIREWALLA_MSP_TOKEN ? 'Set' : 'Missing'}
+- Box ID: ${process.env.FIREWALLA_BOX_ID ? 'Set' : 'Not Set (Optional)'}
+- Default Box ID: ${process.env.FIREWALLA_DEFAULT_BOX_ID ? 'Set' : 'Not Set'}
 - Base URL: ${process.env.FIREWALLA_MSP_BASE_URL ?? 'Default'}
 - Log Level: ${process.env.LOG_LEVEL ?? 'Default'}
 

--- a/src/firewalla/client.ts
+++ b/src/firewalla/client.ts
@@ -4743,15 +4743,19 @@ export class FirewallaClient {
    * Helper method to add box.id qualifier to search queries
    *
    * @param query - Existing query string (optional)
+   * @param box_id - Specific box ID to filter by (optional, falls back to config.boxId)
    * @returns Query string with box.id filter added, or just box.id filter if no query
    * @private
    */
-  private addBoxFilter(query?: string): string | undefined {
-    if (!this.config.boxId) {
+  private addBoxFilter(query?: string, box_id?: string): string | undefined {
+    // Use provided box_id or fall back to config.boxId
+    const boxId = box_id || this.config.boxId;
+
+    if (!boxId) {
       return query;
     }
 
-    const boxFilter = `box.id:${this.config.boxId}`;
+    const boxFilter = `box.id:${boxId}`;
 
     if (!query || query.trim() === '') {
       return boxFilter;

--- a/src/firewalla/client.ts
+++ b/src/firewalla/client.ts
@@ -254,7 +254,10 @@ export class FirewallaClient {
       .update(paramStr)
       .digest('hex')
       .substring(0, 32);
-    return `fw:${this.config.boxId}:${method}:${endpoint.replace(/[^a-zA-Z0-9]/g, '_')}:${paramHash}`;
+
+    // Use 'all-boxes' when no box ID is configured to avoid cache key collisions
+    const boxKey = this.config.boxId || 'all-boxes';
+    return `fw:${boxKey}:${method}:${endpoint.replace(/[^a-zA-Z0-9]/g, '_')}:${paramHash}`;
   }
 
   /**
@@ -4743,19 +4746,15 @@ export class FirewallaClient {
    * Helper method to add box.id qualifier to search queries
    *
    * @param query - Existing query string (optional)
-   * @param box_id - Specific box ID to filter by (optional, falls back to config.boxId)
    * @returns Query string with box.id filter added, or just box.id filter if no query
    * @private
    */
-  private addBoxFilter(query?: string, box_id?: string): string | undefined {
-    // Use provided box_id or fall back to config.boxId
-    const boxId = box_id || this.config.boxId;
-
-    if (!boxId) {
+  private addBoxFilter(query?: string): string | undefined {
+    if (!this.config.boxId) {
       return query;
     }
 
-    const boxFilter = `box.id:${boxId}`;
+    const boxFilter = `box.id:${this.config.boxId}`;
 
     if (!query || query.trim() === '') {
       return boxFilter;

--- a/src/production/config.ts
+++ b/src/production/config.ts
@@ -35,7 +35,7 @@ export function getProductionConfig(): ProductionConfig {
       : getRequiredEnvVar('FIREWALLA_MSP_TOKEN'),
     mspId,
     mspBaseUrl: `https://${mspId}`,
-    boxId: testMode ? 'test-box-id' : getRequiredEnvVar('FIREWALLA_BOX_ID'),
+    boxId: testMode ? 'test-box-id' : (process.env.FIREWALLA_BOX_ID || undefined),
     apiTimeout: getOptionalEnvInt('API_TIMEOUT', 30000, 1000, 300000), // 1s to 5min
     rateLimit: getOptionalEnvInt('API_RATE_LIMIT', 100, 1, 1000), // 1 to 1000 requests per minute
     cacheTtl: getOptionalEnvInt('CACHE_TTL', 300, 0, 3600), // 0s to 1 hour

--- a/src/types.ts
+++ b/src/types.ts
@@ -9,8 +9,8 @@ export interface FirewallaConfig {
   mspId: string;
   /** Full MSP base URL (alternative to mspId for direct URL specification) */
   mspBaseUrl?: string;
-  /** Unique identifier for the Firewalla box/device */
-  boxId: string;
+  /** Unique identifier for the Firewalla box/device (optional - can be provided per-call or as default) */
+  boxId?: string;
   /** API request timeout in milliseconds (default: 30000) */
   apiTimeout: number;
   /** Maximum number of API requests per minute (default: 100) */


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Box ID is now optional; configure FIREWALLA_DEFAULT_BOX_ID as a default or specify per-request instead.
  * Added configurable rate limiting (FIREWALLA_RATE_LIMIT) and cache time-to-live settings (FIREWALLA_CACHE_TTL).

* **Documentation**
  * Updated configuration guidance to reflect that Box ID is optional and clarified default filtering behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->