### PR TITLE
fix: create per-session Server instance for HTTP transport

### DIFF
--- a/src/http-session.ts
+++ b/src/http-session.ts
@@ -1,0 +1,36 @@
+import { Server } from '@modelcontextprotocol/sdk/server/index.js';
+import { StreamableHTTPServerTransport } from '@modelcontextprotocol/sdk/server/streamableHttp.js';
+import { logger } from './monitoring/logger.js';
+
+export async function initializeHttpSession({
+  sessionId,
+  transport,
+  transports,
+  servers,
+  createServerInstance,
+}: {
+  sessionId: string;
+  transport: StreamableHTTPServerTransport;
+  transports: Map<string, StreamableHTTPServerTransport>;
+  servers: Map<string, Server>;
+  createServerInstance: () => Server;
+}): Promise<void> {
+  transports.set(sessionId, transport);
+
+  transport.onclose = () => {
+    logger.info(`HTTP session closed: ${sessionId}`);
+    transports.delete(sessionId);
+    servers.delete(sessionId);
+  };
+
+  const sessionServer = createServerInstance();
+
+  try {
+    await sessionServer.connect(transport);
+    servers.set(sessionId, sessionServer);
+  } catch (error) {
+    transports.delete(sessionId);
+    servers.delete(sessionId);
+    throw error;
+  }
+}

--- a/src/server.ts
+++ b/src/server.ts
@@ -39,6 +39,7 @@ import { setupTools } from './tools/index.js';
 import { setupResources } from './resources/index.js';
 import { setupPrompts } from './prompts/index.js';
 import { logger } from './monitoring/logger.js';
+import { initializeHttpSession } from './http-session.js';
 
 /**
  * UUID v4 validation regex pattern
@@ -965,32 +966,13 @@ export class FirewallaMCPServer {
                   },
                 });
 
-                // Store transport immediately to prevent race condition
-                // This ensures the transport is available before handleRequest is called
-                transports.set(newSessionId, transport);
-
-                // Set up cleanup handler
-                transport.onclose = () => {
-                  const sid = transport.sessionId;
-                  if (sid) {
-                    if (transports.has(sid)) {
-                      logger.info(`HTTP session closed: ${sid}`);
-                      transports.delete(sid);
-                    }
-                    if (servers.has(sid)) {
-                      servers.delete(sid);
-                    }
-                  }
-                };
-
-                // Create a new Server instance for this session
-                // Each HTTP session needs its own Server to avoid
-                // "Already connected to a transport" errors
-                const sessionServer = this.createServerInstance();
-                servers.set(newSessionId, sessionServer);
-
-                // Connect transport to session-specific server
-                await sessionServer.connect(transport);
+                await initializeHttpSession({
+                  sessionId: newSessionId,
+                  transport,
+                  transports,
+                  servers,
+                  createServerInstance: () => this.createServerInstance(),
+                });
               } else {
                 // Invalid request - no session ID or not initialization request
                 res.writeHead(400, { 'Content-Type': 'application/json' });

--- a/src/server.ts
+++ b/src/server.ts
@@ -66,7 +66,18 @@ export class FirewallaMCPServer {
   private firewalla: FirewallaClient;
 
   constructor() {
-    this.server = new Server(
+    this.firewalla = new FirewallaClient(config);
+    this.server = this.createServerInstance();
+  }
+
+  /**
+   * Creates a new MCP Server instance with all handlers registered.
+   * Used once for stdio transport, and per-session for HTTP transport
+   * (each HTTP session needs its own Server instance to avoid
+   * "Already connected to a transport" errors).
+   */
+  private createServerInstance(): Server {
+    const server = new Server(
       {
         name: 'firewalla-mcp-server',
         version: '1.2.0',
@@ -80,16 +91,16 @@ export class FirewallaMCPServer {
       }
     );
 
-    this.firewalla = new FirewallaClient(config);
-    this.setupHandlers();
+    this.registerHandlers(server);
+    return server;
   }
 
   /**
-   * Sets up MCP protocol request handlers for 29-tool architecture
+   * Registers all MCP protocol request handlers on a Server instance
    */
-  private setupHandlers(): void {
+  private registerHandlers(server: Server): void {
     // List available tools - 28-Tool Complete API Coverage
-    this.server.setRequestHandler(ListToolsRequestSchema, async () => {
+    server.setRequestHandler(ListToolsRequestSchema, async () => {
       return {
         tools: [
           // Direct API Endpoints (24 tools)
@@ -830,13 +841,13 @@ export class FirewallaMCPServer {
     });
 
     // Set up tool handlers using the registry
-    setupTools(this.server, this.firewalla);
+    setupTools(server, this.firewalla);
 
     // Set up resources
-    setupResources(this.server, this.firewalla);
+    setupResources(server, this.firewalla);
 
     // Set up prompts
-    setupPrompts(this.server, this.firewalla);
+    setupPrompts(server, this.firewalla);
   }
 
   /**
@@ -871,8 +882,9 @@ export class FirewallaMCPServer {
   private async startHttpTransport(): Promise<void> {
     const { port, path } = config.transport;
 
-    // Map to store transports by session ID
+    // Map to store transports and their associated server instances by session ID
     const transports = new Map<string, StreamableHTTPServerTransport>();
+    const servers = new Map<string, Server>();
 
     // Helper function to parse JSON body from request with size limit
     const parseJsonBody = async (req: IncomingMessage): Promise<unknown> => {
@@ -960,14 +972,25 @@ export class FirewallaMCPServer {
                 // Set up cleanup handler
                 transport.onclose = () => {
                   const sid = transport.sessionId;
-                  if (sid && transports.has(sid)) {
-                    logger.info(`HTTP session closed: ${sid}`);
-                    transports.delete(sid);
+                  if (sid) {
+                    if (transports.has(sid)) {
+                      logger.info(`HTTP session closed: ${sid}`);
+                      transports.delete(sid);
+                    }
+                    if (servers.has(sid)) {
+                      servers.delete(sid);
+                    }
                   }
                 };
 
-                // Connect transport to server
-                await this.server.connect(transport);
+                // Create a new Server instance for this session
+                // Each HTTP session needs its own Server to avoid
+                // "Already connected to a transport" errors
+                const sessionServer = this.createServerInstance();
+                servers.set(newSessionId, sessionServer);
+
+                // Connect transport to session-specific server
+                await sessionServer.connect(transport);
               } else {
                 // Invalid request - no session ID or not initialization request
                 res.writeHead(400, { 'Content-Type': 'application/json' });
@@ -1066,11 +1089,12 @@ export class FirewallaMCPServer {
       void (async () => {
         logger.info('Shutting down HTTP server...');
 
-        // Close all active transports
+        // Close all active transports and their server instances
         for (const [sessionId, transport] of transports.entries()) {
           try {
             await transport.close();
             transports.delete(sessionId);
+            servers.delete(sessionId);
           } catch (error) {
             logger.error(
               `Error closing transport for session ${sessionId}:`,

--- a/tests/server/http-session.test.ts
+++ b/tests/server/http-session.test.ts
@@ -1,0 +1,70 @@
+import { initializeHttpSession } from '../../src/http-session';
+
+describe('initializeHttpSession', () => {
+  it('creates independent server instances for each HTTP session and cleans them up on close', async () => {
+    const transports = new Map();
+    const servers = new Map();
+
+    const serverA = { connect: jest.fn().mockResolvedValue(undefined) };
+    const serverB = { connect: jest.fn().mockResolvedValue(undefined) };
+    const createServerInstance = jest
+      .fn()
+      .mockReturnValueOnce(serverA)
+      .mockReturnValueOnce(serverB);
+
+    const transportA: any = {};
+    const transportB: any = {};
+
+    await initializeHttpSession({
+      sessionId: '11111111-1111-4111-8111-111111111111',
+      transport: transportA,
+      transports,
+      servers,
+      createServerInstance,
+    });
+
+    await initializeHttpSession({
+      sessionId: '22222222-2222-4222-8222-222222222222',
+      transport: transportB,
+      transports,
+      servers,
+      createServerInstance,
+    });
+
+    expect(createServerInstance).toHaveBeenCalledTimes(2);
+    expect(serverA.connect).toHaveBeenCalledWith(transportA);
+    expect(serverB.connect).toHaveBeenCalledWith(transportB);
+    expect(transports.size).toBe(2);
+    expect(servers.size).toBe(2);
+
+    transportA.onclose();
+
+    expect(transports.has('11111111-1111-4111-8111-111111111111')).toBe(false);
+    expect(servers.has('11111111-1111-4111-8111-111111111111')).toBe(false);
+    expect(transports.has('22222222-2222-4222-8222-222222222222')).toBe(true);
+    expect(servers.has('22222222-2222-4222-8222-222222222222')).toBe(true);
+  });
+
+  it('cleans up partially initialized sessions when connect fails', async () => {
+    const transports = new Map();
+    const servers = new Map();
+    const connectError = new Error('connect failed');
+    const createServerInstance = jest
+      .fn()
+      .mockReturnValue({ connect: jest.fn().mockRejectedValue(connectError) });
+    const transport: any = {};
+
+    await expect(
+      initializeHttpSession({
+        sessionId: '33333333-3333-4333-8333-333333333333',
+        transport,
+        transports,
+        servers,
+        createServerInstance,
+      })
+    ).rejects.toThrow('connect failed');
+
+    expect(transports.size).toBe(0);
+    expect(servers.size).toBe(0);
+  });
+});


### PR DESCRIPTION
## Problem

When using HTTP transport, the MCP server only handles one session at a time. After the first `initialize` request, any subsequent `initialize` from a new client throws:

```
Error: Already connected to a transport. Call close() before connecting to a new transport, or use a separate Protocol instance per connection.
```

## Root Cause

`FirewallaMCPServer` creates a single `Server` instance in the constructor and reuses it for every HTTP session via `this.server.connect(transport)`. The MCP SDK's `Server.connect()` throws if already connected.

## Fix

- Extract `createServerInstance()` helper that creates a fully configured `Server` with all handlers
- In HTTP mode, create a new `Server` per session instead of reusing `this.server`
- Track per-session `Server` instances in a `Map` alongside transports
- Clean up both on session close
- Stdio transport unchanged (single Server, single Transport)

## Testing

Verified locally: 3 concurrent HTTP sessions initialized and queried independently. No "Already connected" errors.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Per-session HTTP server architecture with improved session lifecycle, validation, cleanup, and logging.

* **New Features**
  * Paginated flow fetching with per-device bandwidth aggregation.
  * Flow records include domain and network metadata for richer context.

* **Bug Fixes**
  * Unified streaming and batch flow handling to preserve client-provided fields and remove stale enrichment.

* **Documentation**
  * Added metadata headers and new/expanded guides across multiple docs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->